### PR TITLE
feat(ingest): resume_state.py — ZIP resume tracking (#4)

### DIFF
--- a/jobs/ingest/src/resume_state.py
+++ b/jobs/ingest/src/resume_state.py
@@ -1,0 +1,38 @@
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+_DEFAULT_STATE_DIR = Path.home() / ".theboss-ingest"
+_STATE_FILE = "state.json"
+
+
+class ResumeState:
+    def __init__(self, state_dir: str | None = None):
+        if state_dir is not None:
+            self._dir = Path(state_dir)
+        else:
+            env = os.environ.get("LOCAL_STATE_DIR")
+            self._dir = Path(env) if env else _DEFAULT_STATE_DIR
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._path = self._dir / _STATE_FILE
+        self._state: dict = self._load()
+
+    def _load(self) -> dict:
+        if self._path.exists():
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        return {}
+
+    def _save(self) -> None:
+        self._path.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
+
+    def is_done(self, url: str) -> bool:
+        return self._state.get(url, {}).get("status") == "completed"
+
+    def mark_done(self, url: str) -> None:
+        self._state[url] = {
+            "status": "completed",
+            "completed_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        self._save()

--- a/jobs/ingest/tests/test_resume_state.py
+++ b/jobs/ingest/tests/test_resume_state.py
@@ -1,0 +1,52 @@
+import json
+import os
+import pytest
+from src.resume_state import ResumeState
+
+
+def test_is_done_returns_false_for_unknown_url(tmp_path):
+    state = ResumeState(state_dir=str(tmp_path))
+    assert state.is_done("https://takeout.google.com/download/abc") is False
+
+
+def test_mark_done_then_is_done_returns_true(tmp_path):
+    url = "https://takeout.google.com/download/abc"
+    state = ResumeState(state_dir=str(tmp_path))
+    state.mark_done(url)
+    assert state.is_done(url) is True
+
+
+def test_state_persists_across_instances(tmp_path):
+    url = "https://takeout.google.com/download/abc"
+    ResumeState(state_dir=str(tmp_path)).mark_done(url)
+    assert ResumeState(state_dir=str(tmp_path)).is_done(url) is True
+
+
+def test_state_dir_created_automatically(tmp_path):
+    state_dir = str(tmp_path / "nested" / "state")
+    ResumeState(state_dir=state_dir).mark_done("https://example.com/x")
+    assert os.path.isdir(state_dir)
+
+
+def test_local_state_dir_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_STATE_DIR", str(tmp_path))
+    url = "https://takeout.google.com/download/abc"
+    ResumeState().mark_done(url)
+    assert ResumeState().is_done(url) is True
+
+
+def test_multiple_urls_tracked_independently(tmp_path):
+    url_a = "https://takeout.google.com/download/a"
+    url_b = "https://takeout.google.com/download/b"
+    state = ResumeState(state_dir=str(tmp_path))
+    state.mark_done(url_a)
+    assert state.is_done(url_a) is True
+    assert state.is_done(url_b) is False
+
+
+def test_state_file_format(tmp_path):
+    url = "https://takeout.google.com/download/abc"
+    ResumeState(state_dir=str(tmp_path)).mark_done(url)
+    data = json.loads((tmp_path / "state.json").read_text())
+    assert data[url]["status"] == "completed"
+    assert "completed_at" in data[url]


### PR DESCRIPTION
## Summary

- Adds `ResumeState` class that persists completed ZIP URLs to `~/.theboss-ingest/state.json`
- `is_done(url)` / `mark_done(url)` interface for the local CLI to skip already-processed ZIPs on re-run
- State dir configurable via `LOCAL_STATE_DIR` env var; created automatically on first use

## Test plan

- [x] 7 unit tests covering: unknown URL, mark→is_done, persistence across instances, auto dir creation, env var override, multiple URLs, file format
- [x] All existing tests pass

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)