### PR TITLE
feat(ingest+app): Firestore schema — youtube_video_id for video documents (#5)

### DIFF
--- a/app/src/lib/photo-index-repository.ts
+++ b/app/src/lib/photo-index-repository.ts
@@ -4,6 +4,7 @@ export interface PhotoDoc {
   takenAt: Date;
   previewGcsPath: string;
   originalGcsPath: string;
+  youtubeVideoId?: string;
   width: number;
   height: number;
   latitude: number | null;
@@ -15,6 +16,7 @@ export interface PhotoResult {
   takenAt: Date;
   previewGcsPath: string | null;
   originalGcsPath: string;
+  youtubeVideoId?: string;
   width: number | null;
   height: number | null;
 }
@@ -53,6 +55,7 @@ export class PhotoIndexRepository {
         takenAt: data.taken_at.toDate(),
         previewGcsPath: data.preview_gcs_path ?? null,
         originalGcsPath: data.original_gcs_path,
+        youtubeVideoId: data.youtube_video_id ?? undefined,
         width: data.width ?? null,
         height: data.height ?? null,
       };

--- a/jobs/ingest/src/photo_index_repository.py
+++ b/jobs/ingest/src/photo_index_repository.py
@@ -8,11 +8,12 @@ class PhotoDoc:
     google_photos_id: str
     filename: str
     taken_at: datetime
-    original_gcs_path: str
     latitude: Optional[float]
     longitude: Optional[float]
     media_type: str = "photo"  # "photo" or "video"
+    original_gcs_path: Optional[str] = None
     preview_gcs_path: Optional[str] = None
+    youtube_video_id: Optional[str] = None
     width: Optional[int] = None
     height: Optional[int] = None
 
@@ -39,10 +40,13 @@ class PhotoIndexRepository:
             "taken_at": doc.taken_at,
             "media_type": doc.media_type,
             "preview_gcs_path": doc.preview_gcs_path,
-            "original_gcs_path": doc.original_gcs_path,
             "width": doc.width,
             "height": doc.height,
             "latitude": doc.latitude,
             "longitude": doc.longitude,
         }
+        if doc.youtube_video_id is not None:
+            data["youtube_video_id"] = doc.youtube_video_id
+        else:
+            data["original_gcs_path"] = doc.original_gcs_path
         self._db.collection(self.COLLECTION).document(doc.google_photos_id).set(data)

--- a/jobs/ingest/tests/test_photo_index_repository_video.py
+++ b/jobs/ingest/tests/test_photo_index_repository_video.py
@@ -1,0 +1,71 @@
+"""Tests for youtube_video_id support in PhotoIndexRepository."""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+import pytest
+
+from src.photo_index_repository import PhotoIndexRepository, PhotoDoc
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def repo(mock_db):
+    return PhotoIndexRepository(db=mock_db)
+
+
+def _image_doc() -> PhotoDoc:
+    return PhotoDoc(
+        google_photos_id="IMG001",
+        filename="IMG_0001.jpg",
+        taken_at=datetime(2021, 1, 1, tzinfo=timezone.utc),
+        preview_gcs_path="previews/IMG001.webp",
+        original_gcs_path="originals/IMG001.jpg",
+        width=1280,
+        height=960,
+        latitude=None,
+        longitude=None,
+        media_type="photo",
+    )
+
+
+def _video_doc() -> PhotoDoc:
+    return PhotoDoc(
+        google_photos_id="VID001",
+        filename="VID_0001.mp4",
+        taken_at=datetime(2021, 7, 4, tzinfo=timezone.utc),
+        preview_gcs_path=None,
+        original_gcs_path=None,
+        width=None,
+        height=None,
+        latitude=None,
+        longitude=None,
+        media_type="video",
+        youtube_video_id="yt_abc123",
+    )
+
+
+def test_upsert_video_writes_youtube_video_id(repo, mock_db):
+    repo.upsert(_video_doc())
+    written = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+    assert written["youtube_video_id"] == "yt_abc123"
+
+
+def test_upsert_video_omits_original_gcs_path(repo, mock_db):
+    repo.upsert(_video_doc())
+    written = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+    assert "original_gcs_path" not in written
+
+
+def test_upsert_image_writes_original_gcs_path(repo, mock_db):
+    repo.upsert(_image_doc())
+    written = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+    assert written["original_gcs_path"] == "originals/IMG001.jpg"
+
+
+def test_upsert_image_omits_youtube_video_id(repo, mock_db):
+    repo.upsert(_image_doc())
+    written = mock_db.collection.return_value.document.return_value.set.call_args[0][0]
+    assert "youtube_video_id" not in written


### PR DESCRIPTION
## Summary

- `PhotoDoc` dataclass: `original_gcs_path` made optional, `youtube_video_id: Optional[str]` added
- `PhotoIndexRepository.upsert()`: writes `youtube_video_id` for videos, `original_gcs_path` for images (never both)
- TypeScript `PhotoDoc` + `PhotoResult`: `youtubeVideoId?: string` added, mapped from `youtube_video_id` Firestore field

## Test plan

- [x] 4 new tests: video doc writes `youtube_video_id`, omits `original_gcs_path`; image doc writes `original_gcs_path`, omits `youtube_video_id`
- [x] All 34 existing tests pass (no regression)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)