### PR TITLE
feat(ingest): youtube_uploader.py — YouTube upload with playlist management (#3)

### DIFF
--- a/jobs/ingest/requirements.txt
+++ b/jobs/ingest/requirements.txt
@@ -1,8 +1,10 @@
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
+google-auth-oauthlib==1.2.0
 google-api-python-client==2.129.0
 google-cloud-storage==2.16.0
 google-cloud-firestore==2.16.0
+google-cloud-secret-manager==2.20.0
 Pillow==11.2.1
 pillow-heif==0.21.0
 requests==2.32.2

--- a/jobs/ingest/src/youtube_uploader.py
+++ b/jobs/ingest/src/youtube_uploader.py
@@ -1,0 +1,142 @@
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import google.oauth2.credentials
+from google.cloud import secretmanager
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+import pickle
+
+
+_SCOPES = ["https://www.googleapis.com/auth/youtube.upload",
+           "https://www.googleapis.com/auth/youtube"]
+
+
+@dataclass
+class LocalTokenAuth:
+    token_path: str
+    client_id: str
+    client_secret: str
+
+
+@dataclass
+class SecretManagerAuth:
+    secret_name: str
+    project_id: str
+
+
+def build_youtube_client(credentials):
+    return build("youtube", "v3", credentials=credentials)
+
+
+def _local_credentials(auth: LocalTokenAuth):
+    creds = None
+    if os.path.exists(auth.token_path):
+        with open(auth.token_path, "rb") as f:
+            creds = pickle.load(f)
+    if creds and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+    elif not creds or not creds.valid:
+        flow = InstalledAppFlow.from_client_config(
+            {
+                "installed": {
+                    "client_id": auth.client_id,
+                    "client_secret": auth.client_secret,
+                    "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob"],
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                }
+            },
+            scopes=_SCOPES,
+        )
+        creds = flow.run_local_server(port=0)
+        with open(auth.token_path, "wb") as f:
+            pickle.dump(creds, f)
+    return creds
+
+
+def _secret_manager_credentials(auth: SecretManagerAuth):
+    client = secretmanager.SecretManagerServiceClient()
+    secret_path = f"projects/{auth.project_id}/secrets/{auth.secret_name}/versions/latest"
+    response = client.access_secret_version(name=secret_path)
+    refresh_token = response.payload.data.decode("utf-8").strip()
+    return google.oauth2.credentials.Credentials(
+        token=None,
+        refresh_token=refresh_token,
+        token_uri="https://oauth2.googleapis.com/token",
+        scopes=_SCOPES,
+    )
+
+
+class YouTubeUploader:
+    def __init__(self, auth: LocalTokenAuth | SecretManagerAuth):
+        if isinstance(auth, LocalTokenAuth):
+            creds = _local_credentials(auth)
+        else:
+            creds = _secret_manager_credentials(auth)
+        self._youtube = build_youtube_client(creds)
+        self._playlist_cache: dict[str, str] = {}
+
+    def _get_or_create_playlist(self, title: str) -> str:
+        if title in self._playlist_cache:
+            return self._playlist_cache[title]
+
+        response = (
+            self._youtube.playlists()
+            .list(part="snippet", mine=True, maxResults=50)
+            .execute()
+        )
+        for item in response.get("items", []):
+            if item["snippet"]["title"] == title:
+                playlist_id = item["id"]
+                self._playlist_cache[title] = playlist_id
+                return playlist_id
+
+        new_playlist = (
+            self._youtube.playlists()
+            .insert(
+                part="snippet,status",
+                body={
+                    "snippet": {"title": title},
+                    "status": {"privacyStatus": "private"},
+                },
+            )
+            .execute()
+        )
+        playlist_id = new_playlist["id"]
+        self._playlist_cache[title] = playlist_id
+        return playlist_id
+
+    def upload(self, file_path: str, taken_at: datetime) -> str:
+        playlist_title = taken_at.strftime("%Y-%m")
+        playlist_id = self._get_or_create_playlist(playlist_title)
+
+        media = MediaFileUpload(file_path, resumable=True)
+        request = self._youtube.videos().insert(
+            part="snippet,status",
+            body={
+                "snippet": {"title": os.path.basename(file_path)},
+                "status": {"privacyStatus": "private"},
+            },
+            media_body=media,
+        )
+        response = None
+        while response is None:
+            _, response = request.next_chunk()
+        video_id = response["id"]
+
+        self._youtube.playlistItems().insert(
+            part="snippet",
+            body={
+                "snippet": {
+                    "playlistId": playlist_id,
+                    "resourceId": {"kind": "youtube#video", "videoId": video_id},
+                }
+            },
+        ).execute()
+
+        return video_id

--- a/jobs/ingest/tests/test_youtube_uploader.py
+++ b/jobs/ingest/tests/test_youtube_uploader.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from src.youtube_uploader import YouTubeUploader, LocalTokenAuth, SecretManagerAuth
+
+
+@pytest.fixture()
+def mock_youtube():
+    return MagicMock()
+
+
+@pytest.fixture()
+def mock_media():
+    with patch("src.youtube_uploader.MediaFileUpload") as m:
+        yield m
+
+
+@pytest.fixture()
+def uploader(mock_youtube, mock_media):
+    auth = LocalTokenAuth(
+        token_path="/tmp/token.json",
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+    mock_creds = MagicMock()
+    with (
+        patch("src.youtube_uploader._local_credentials", return_value=mock_creds),
+        patch("src.youtube_uploader.build_youtube_client", return_value=mock_youtube),
+    ):
+        yield YouTubeUploader(auth), mock_youtube
+
+
+def _taken_at(year=2023, month=7):
+    return datetime(year, month, 15, tzinfo=timezone.utc)
+
+
+def _setup_upload(mock_youtube, video_id="vid123"):
+    mock_youtube.videos.return_value.insert.return_value.next_chunk.return_value = (
+        None,
+        {"id": video_id},
+    )
+
+
+def _setup_no_playlists(mock_youtube):
+    mock_youtube.playlists.return_value.list.return_value.execute.return_value = {
+        "items": []
+    }
+
+
+def _setup_existing_playlist(mock_youtube, title="2023-07", playlist_id="pl123"):
+    mock_youtube.playlists.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": playlist_id, "snippet": {"title": title}}]
+    }
+
+
+def _setup_playlist_insert(mock_youtube, playlist_id="pl_new"):
+    mock_youtube.playlists.return_value.insert.return_value.execute.return_value = {
+        "id": playlist_id
+    }
+
+
+def test_upload_returns_video_id(uploader):
+    u, mock_yt = uploader
+    _setup_no_playlists(mock_yt)
+    _setup_playlist_insert(mock_yt)
+    _setup_upload(mock_yt, video_id="abc123")
+    result = u.upload("/tmp/video.mp4", _taken_at())
+    assert result == "abc123"
+
+
+def test_new_playlist_created_when_none_exists(uploader):
+    u, mock_yt = uploader
+    _setup_no_playlists(mock_yt)
+    _setup_playlist_insert(mock_yt, playlist_id="new_pl")
+    _setup_upload(mock_yt)
+    u.upload("/tmp/video.mp4", _taken_at(2023, 7))
+    mock_yt.playlists.return_value.insert.assert_called_once()
+    insert_call = mock_yt.playlists.return_value.insert.call_args
+    body = insert_call[1]["body"]
+    assert body["snippet"]["title"] == "2023-07"
+    assert body["status"]["privacyStatus"] == "private"
+
+
+def test_existing_playlist_reused_no_duplicate(uploader):
+    u, mock_yt = uploader
+    _setup_existing_playlist(mock_yt, title="2023-07", playlist_id="existing_pl")
+    _setup_upload(mock_yt)
+    u.upload("/tmp/video.mp4", _taken_at(2023, 7))
+    mock_yt.playlists.return_value.insert.assert_not_called()
+
+
+def test_playlist_id_cached_across_uploads(uploader):
+    u, mock_yt = uploader
+    _setup_existing_playlist(mock_yt, title="2023-07", playlist_id="cached_pl")
+    _setup_upload(mock_yt)
+    u.upload("/tmp/video.mp4", _taken_at(2023, 7))
+    u.upload("/tmp/video2.mp4", _taken_at(2023, 7))
+    # playlists.list should only be called once (second call uses cache)
+    assert mock_yt.playlists.return_value.list.call_count == 1
+
+
+def test_video_added_to_playlist(uploader):
+    u, mock_yt = uploader
+    _setup_existing_playlist(mock_yt, title="2023-07", playlist_id="pl_abc")
+    _setup_upload(mock_yt, video_id="vid_xyz")
+    u.upload("/tmp/video.mp4", _taken_at(2023, 7))
+    mock_yt.playlistItems.return_value.insert.assert_called_once()
+    body = mock_yt.playlistItems.return_value.insert.call_args[1]["body"]
+    assert body["snippet"]["playlistId"] == "pl_abc"
+    assert body["snippet"]["resourceId"]["videoId"] == "vid_xyz"
+
+
+def test_secret_manager_auth_reads_secret():
+    auth = SecretManagerAuth(secret_name="youtube-refresh-token", project_id="my-project")
+    mock_sm = MagicMock()
+    mock_sm.access_secret_version.return_value.payload.data = b"my-refresh-token"
+    mock_creds = MagicMock()
+    mock_yt = MagicMock()
+    _setup_no_playlists(mock_yt)
+    _setup_playlist_insert(mock_yt)
+    _setup_upload(mock_yt)
+    with (
+        patch("src.youtube_uploader._secret_manager_credentials", return_value=mock_creds) as mock_sm_creds,
+        patch("src.youtube_uploader.build_youtube_client", return_value=mock_yt),
+        patch("src.youtube_uploader.MediaFileUpload"),
+    ):
+        u = YouTubeUploader(auth)
+        u.upload("/tmp/video.mp4", _taken_at())
+    mock_sm_creds.assert_called_once_with(auth)


### PR DESCRIPTION
## Summary

- New `YouTubeUploader` class with dual auth: `LocalTokenAuth` (browser OAuth flow, persists `token.json`) and `SecretManagerAuth` (reads refresh token from GCP Secret Manager)
- Uploads videos as private; creates or reuses `YYYY-MM` playlists based on `taken_at`; playlist IDs cached in-memory to avoid redundant API calls
- Adds `google-auth-oauthlib` and `google-cloud-secret-manager` to requirements

## Test plan

- [x] 6 unit tests: upload returns video ID, new playlist created, existing playlist reused (no duplicate), playlist ID cached across uploads, video added to playlist, Secret Manager auth path
- [x] All existing tests unaffected (no shared files changed)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)